### PR TITLE
게이트웨이 JWT 인가 처리 구현

### DIFF
--- a/src/main/java/com/qring/gateway/filter/post/LoggingFilter.java
+++ b/src/main/java/com/qring/gateway/filter/post/LoggingFilter.java
@@ -1,0 +1,28 @@
+package com.qring.gateway.filter.post;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j(topic = "Gateway LoggingFilter Log")
+public class LoggingFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, org.springframework.cloud.gateway.filter.GatewayFilterChain chain) {
+        return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+            ServerHttpResponse response = exchange.getResponse();
+            log.info("Request URI is {}", response.getStatusCode());
+        }));
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+}

--- a/src/main/java/com/qring/gateway/filter/pre/JwtAuthorizationFilter.java
+++ b/src/main/java/com/qring/gateway/filter/pre/JwtAuthorizationFilter.java
@@ -1,0 +1,113 @@
+package com.qring.gateway.filter.pre;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.SecretKey;
+
+@Component
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter  implements GlobalFilter, Ordered  {
+
+    // Header KEY 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${service.jwt.secret-key}")
+    private String secretKey;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+
+        log.info("Path 확인");
+        if (path.equals("/v1/auth/login") || path.equals("/v1/users/join")) {
+            log.info("요청 URI가 인증/인가 제외 경로입니다. 필터를 통과합니다.");
+            return chain.filter(exchange);
+        }
+
+        log.info("Authorization 헤더에서 JWT 토큰 추출 시도");
+        String token = getJwtFromHeader(exchange);
+
+        if (token == null || !validateToken(token)) {
+            log.warn("JWT 토큰이 유효하지 않습니다. 요청을 차단합니다.");
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        log.info("JWT 토큰 검증 성공: 사용자 인증 및 인가 통과");
+        return chain.filter(addUserInfoHeader(exchange, token));
+    }
+
+    private String getJwtFromHeader(ServerWebExchange exchange) {
+        String bearerToken = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            log.debug("Authorization 헤더에서 Bearer 토큰 추출 성공");
+            return bearerToken.substring(7);
+        }
+
+        log.warn("Authorization 헤더가 없거나 잘못된 형식입니다.");
+        return null;
+    }
+
+    private boolean validateToken(String token) {
+        try {
+            getClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    private ServerWebExchange addUserInfoHeader(ServerWebExchange exchange, String token) {
+        String userId = getUserIdFromToken(token);
+        ServerHttpRequest req = exchange.getRequest()
+                .mutate()
+                .header("X-User-Id", userId)
+                .build();
+
+        return exchange.mutate()
+                .request(req)
+                .build();
+    }
+
+    private Jws<Claims> getClaimsJws(String token) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    private String getUserIdFromToken(String token) {
+        Jws<Claims> claimsJws = getClaimsJws(token);
+        return String.valueOf(claimsJws.getBody().get("userId", Long.class));
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,12 +5,12 @@ spring:
         - id: auth-service
           uri: lb://auth-service
           predicates:
-            - Path=/v1/auth/**
+            - Path=/v1/auth/**, /v1/users/**
 
         - id: message-service
           uri: lb://message-service
           predicates:
-            - Path=/v1/messages/**
+            - Path=/v1/messages/**, /v1/ai/**
 
         - id: coupon-service
           uri: lb://coupon-service

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
         - id: message-service
           uri: lb://message-service
           predicates:
-            - Path=/v1/messages/**, /v1/ai/**
+            - Path=/v1/messages/**
 
         - id: coupon-service
           uri: lb://coupon-service


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1 

## 📝 Description

- `PreFilter` 역할을 수행하는 `JwtAuthorizationFilter` 필터를 구현했습니다.
- 로그인과 회원가입 path 는 인가 과정을 거치지 않고 필터를 통과합니다.
- `PostFilter` 역할을 수행하는 `LoggingFilter` 필터를 구현했습니다.
- 모든 요청에 대한 응답이 로그로 출력됩니다.

### 추후 구현 예정 기능

> 1. 토스의 `PASSPORT` 방식을 구현할 것입니다.
>  - 해당 `PASSPORT` 를 통해 각 서비스들은 추가 요청 없이 유저의 정보를 이용할 수 있을 것입니다.
> 2. ELK 스택 구축
>   - ELK 스택 환경을 구축하여, 모든 요청 및 응답에 대한 로그를 중앙집중화 하겠습니다.

## 💬 To Reivewers

- 일단 간단하게만 구현했습니다. 계속 develop 하겠습니다.
