### PR TITLE
Redis 메시지 구독 기능 추가

### DIFF
--- a/src/main/java/com/qring/gateway/redis/RedisMessageSubscriber.java
+++ b/src/main/java/com/qring/gateway/redis/RedisMessageSubscriber.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j(topic = "RedisSubscriber Log")
-public class RedisSubscriber {
+@Slf4j(topic = "RedisMessageSubscriber Log")
+public class RedisMessageSubscriber {
 
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
 

--- a/src/main/java/com/qring/gateway/redis/RedisSubscriber.java
+++ b/src/main/java/com/qring/gateway/redis/RedisSubscriber.java
@@ -1,0 +1,29 @@
+package com.qring.gateway.redis;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "RedisSubscriber Log")
+public class RedisSubscriber {
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    @PostConstruct
+    public void subscribeToUserUpdates() {
+        reactiveRedisTemplate.listenToChannel("user-modification-channel")
+                .doOnNext(message -> {
+                    String userId = message.getMessage();
+                    log.info("회원 정보 업데이트 감지. Redis에서 userId={} 데이터를 만료합니다.", userId);
+
+                    reactiveRedisTemplate.delete(userId)
+                            .doOnSuccess(deleted -> log.info("Redis에서 userId={} 데이터 삭제 완료: {}", userId, deleted))
+                            .subscribe();
+                })
+                .subscribe();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #7 

## 📝 Description

- `user-modification-channel` 해당 채널을 구독하여, 메시지를 소비하는 기능을 구현했습니다.
- 해당 메시지에서 `userId` 를 받아 해당 데이터가 `key` 로 존재하는 `redis` 데이터를 제거합니다.

### Gateway Message Subscriber
```java
@Component
@RequiredArgsConstructor
@Slf4j(topic = "RedisMessageSubscriber Log")
public class RedisMessageSubscriber {

    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;

    @PostConstruct
    public void subscribeToUserUpdates() {
        reactiveRedisTemplate.listenToChannel("user-modification-channel")
                .doOnNext(message -> {
                    String userId = message.getMessage();
                    log.info("회원 정보 업데이트 감지. Redis에서 userId={} 데이터를 만료합니다.", userId);

                    reactiveRedisTemplate.delete(userId)
                            .doOnSuccess(deleted -> log.info("Redis에서 userId={} 데이터 삭제 완료: {}", userId, deleted))
                            .subscribe();
                })
                .subscribe();
    }
}
```
```java
2025-01-05T19:56:48.288+09:00  INFO 54345 --- [gateway-service] [io-19001-exec-3] JwtAuthorizationFilterV2 Log             : JWT 토큰 검증 성공. Redis에서 Passport 확인
2025-01-05T19:56:48.291+09:00  INFO 54345 --- [gateway-service] [ioEventLoop-4-1] JwtAuthorizationFilterV2 Log             : Redis에서 Passport Token 조회 성공: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlMiIsInVzZXJJZCI6NjYyMTYwNjI0NjEwODY2MDM5LCJyb2xlIjoi6rSA66as7J6QIiwic2xhY2tFbWFpbCI6InVzZXJAZXhhbXBsZTEuY29tIiwiZXhwIjoxNzM2MDc0NjU4LCJpYXQiOjE3MzYwNzQzNTh9.Ic8Jc7YIumLcOpHNM9vZIy2KG44rZQHTvJMWUxxqNVk
2025-01-05T19:56:48.551+09:00  INFO 54345 --- [gateway-service] [ioEventLoop-4-2] RedisSubscriber Log                      : 회원 정보 업데이트 감지. Redis에서 userId=662160624610866039 데이터를 만료합니다.
2025-01-05T19:56:48.557+09:00  INFO 54345 --- [gateway-service] [ioEventLoop-4-1] RedisSubscriber Log                      : Redis에서 userId=662160624610866039 데이터 삭제 완료: 1
2025-01-05T19:56:48.573+09:00  INFO 54345 --- [gateway-service] [ctor-http-nio-6] Gateway LoggingFilter Log                : Request URI is 200 OK
```
- `user-modification-channel` 채널에 발행된 메시지를 소비합니다.
- 메시지를 소비하면, 해당 `userId` 가 `key` 로 존재하는 값을 `Redis` 에서 제거합니다.
- 이로써, 유저는 다음 인가과정에서 최신화된 `Passport` 를 발급받게 됩니다.

## 💬 To Reivewers

